### PR TITLE
replace np.vectorize by using vectorized numpy/scipy functions

### DIFF
--- a/sklearn_lvq/gmlvq.py
+++ b/sklearn_lvq/gmlvq.py
@@ -127,7 +127,7 @@ class GmlvqModel(GlvqModel):
         distcorrectpluswrong = distcorrect + distwrong
         distcorectminuswrong = distcorrect - distwrong
         mu = distcorectminuswrong / distcorrectpluswrong
-        mu = np.vectorize(self.phi_prime)(mu)
+        mu = self.phi_prime(mu)
         mu *= self.c_[label_equals_prototype.argmax(1), d_wrong.argmin(1)]
 
         g = np.zeros(variables.shape)
@@ -190,8 +190,8 @@ class GmlvqModel(GlvqModel):
         if self.regularization > 0:
             reg_term = self.regularization * log(
                 np.linalg.det(omega_t.conj().T.dot(omega_t)))
-            return np.vectorize(self.phi)(mu).sum(0) - reg_term  # f
-        return np.vectorize(self.phi)(mu).sum(0)
+            return self.phi(mu).sum(0) - reg_term  # f
+        return self.phi(mu).sum(0)
 
     def _optimize(self, x, y, random_state):
         if not isinstance(self.regularization,

--- a/sklearn_lvq/grlvq.py
+++ b/sklearn_lvq/grlvq.py
@@ -116,7 +116,7 @@ class GrlvqModel(GlvqModel):
         distcorrectpluswrong = distcorrect + distwrong
         distcorectminuswrong = distcorrect - distwrong
         mu = distcorectminuswrong / distcorrectpluswrong
-        mu = np.vectorize(self.phi_prime)(mu)
+        mu = self.phi_prime(mu)
 
         g = np.zeros(prototypes.shape)
         distcorrectpluswrong = 4 / distcorrectpluswrong ** 2
@@ -173,7 +173,7 @@ class GrlvqModel(GlvqModel):
         mu = distcorectminuswrong / distcorrectpluswrong
         mu *= self.c_[label_equals_prototype.argmax(1), d_wrong.argmin(1)]
 
-        return np.vectorize(self.phi)(mu).sum(0)
+        return self.phi(mu).sum(0)
 
     def _optimize(self, x, y, random_state):
         if not isinstance(self.regularization,

--- a/sklearn_lvq/grmlvq.py
+++ b/sklearn_lvq/grmlvq.py
@@ -133,7 +133,7 @@ class GrmlvqModel(GlvqModel):
         distcorrectpluswrong = distcorrect + distwrong
         distcorectminuswrong = distcorrect - distwrong
         mu = distcorectminuswrong / distcorrectpluswrong
-        mu = np.vectorize(self.phi_prime)(mu)
+        mu = self.phi_prime(mu)
         mu *= self.c_[label_equals_prototype.argmax(1), d_wrong.argmin(1)]
 
         g = np.zeros(variables.shape)
@@ -205,8 +205,8 @@ class GrmlvqModel(GlvqModel):
         if self.regularization > 0:
             reg_term = self.regularization * log(
                 np.linalg.det(omega_t.conj().T.dot(omega_t)))
-            return np.vectorize(self.phi)(mu).sum(0) - reg_term  # f
-        return np.vectorize(self.phi)(mu).sum(0)
+            return self.phi(mu).sum(0) - reg_term  # f
+        return self.phi(mu).sum(0)
 
     def _optimize(self, x, y, random_state):
         if not isinstance(self.regularization,

--- a/sklearn_lvq/lgmlvq.py
+++ b/sklearn_lvq/lgmlvq.py
@@ -138,7 +138,7 @@ class LgmlvqModel(GlvqModel):
         distcorrectpluswrong = distcorrect + distwrong
         distcorectminuswrong = distcorrect - distwrong
         mu = distcorectminuswrong / distcorrectpluswrong
-        mu = np.vectorize(self.phi_prime)(mu)
+        mu = self.phi_prime(mu)
 
         g = np.zeros(variables.shape)
         normfactors = 4 / distcorrectpluswrong ** 2
@@ -220,9 +220,9 @@ class LgmlvqModel(GlvqModel):
 
             t = np.array([test(x) for x in psis])
             reg_term = self.regularization_ * t
-            return np.vectorize(self.phi)(mu) - 1 / nb_samples * reg_term[
+            return self.phi(mu) - 1 / nb_samples * reg_term[
                 pidxcorrect] - 1 / nb_samples * reg_term[pidxwrong]
-        return np.vectorize(self.phi)(mu).sum(0)
+        return self.phi(mu).sum(0)
 
     def _optimize(self, x, y, random_state):
         nb_prototypes, nb_features = self.w_.shape


### PR DESCRIPTION
Removing np.vectorize for phi and phi_prime usages by using an already vectorized implementation of the sigmoid function reduces the runtime of the GMLVQ by ~15% on the digits dataset and ~30% on the wine dataset.

